### PR TITLE
Add org triage and dependabot batch workflows; improve auto-merge handling

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
             exit 0
           fi
 
-          gh pr list --repo "$REPO" --state open --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
+          gh pr list --repo "$REPO" --state open --limit 200 --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             draft=$(echo "$pr" | jq -r '.isDraft')
             merge_state=$(echo "$pr" | jq -r '.mergeStateStatus')

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,32 +5,43 @@ on:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
   check_suite:
     types: [completed]
-  status:
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: auto-merge-prs
+  cancel-in-progress: false
+
 jobs:
   auto-merge:
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' || github.event.check_suite.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Enable auto-merge for PR
+      - name: Enable auto-merge where eligible
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          # Use gh CLI to enable auto-merge (squash)
-          # Only if checks are passing and not a draft
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            gh pr merge --auto --squash "${{ github.event.pull_request.number }}" || echo "Could not enable auto-merge"
-          else
-            # For other triggers, we might need to find the PR
-            PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --format "{{.number}}")
-            if [ -n "$PR_NUMBER" ]; then
-              gh pr merge --auto --squash "$PR_NUMBER" || echo "Could not enable auto-merge for PR $PR_NUMBER"
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+              echo "Draft PR detected; skipping"
+              exit 0
             fi
+
+            gh pr merge "${{ github.event.pull_request.number }}" --repo "$REPO" --auto --squash || true
+            exit 0
           fi
+
+          gh pr list --repo "$REPO" --state open --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            draft=$(echo "$pr" | jq -r '.isDraft')
+            merge_state=$(echo "$pr" | jq -r '.mergeStateStatus')
+
+            if [ "$draft" = "false" ] && [ "$merge_state" = "CLEAN" ]; then
+              gh pr merge "$number" --repo "$REPO" --auto --squash || true
+            fi
+          done

--- a/.github/workflows/org-dependabot-batch-manager.yml
+++ b/.github/workflows/org-dependabot-batch-manager.yml
@@ -1,1 +1,97 @@
-404: Not Found
+name: Dependabot Batch Manager
+
+on:
+  schedule:
+    - cron: "30 */6 * * *" # Every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-batch-manager
+  cancel-in-progress: false
+
+jobs:
+  process-dependabot-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install dependencies
+        if: hashFiles('package-lock.json', 'package.json') != ''
+        run: npm ci || npm install
+
+      - name: Find open Dependabot PRs
+        id: deps
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr list --repo "$REPO" --state open --search "author:dependabot[bot]" --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
+          count=$(jq 'length' dependabot-prs.json)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Found $count Dependabot PR(s)."
+
+      - name: Apply lint/build fixes on each Dependabot branch
+        if: steps.deps.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          jq -c '.[]' dependabot-prs.json | while read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            branch=$(echo "$pr" | jq -r '.headRefName')
+            draft=$(echo "$pr" | jq -r '.isDraft')
+
+            echo "Processing Dependabot PR #$number on branch $branch"
+            git checkout --detach
+            git reset --hard
+            git clean -fd
+
+            if ! git fetch origin "$branch":"$branch"; then
+              echo "Could not fetch branch $branch; skipping PR #$number"
+              continue
+            fi
+
+            git checkout "$branch"
+
+            npm run lint -- --fix || true
+            npm run build || true
+
+            if ! git diff --quiet; then
+              git add -A
+              git commit -m "chore: auto-fix dependabot PR checks"
+              git push origin "HEAD:$branch"
+            else
+              echo "No auto-fix changes for PR #$number"
+            fi
+
+            if [ "$draft" = "false" ]; then
+              gh pr merge "$number" --repo "$REPO" --auto --squash || true
+            fi
+          done
+
+      - name: Upload Dependabot processing log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependabot-prs
+          path: dependabot-prs.json
+          if-no-files-found: ignore

--- a/.github/workflows/org-dependabot-batch-manager.yml
+++ b/.github/workflows/org-dependabot-batch-manager.yml
@@ -39,7 +39,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh pr list --repo "$REPO" --state open --search "author:dependabot[bot]" --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
+          gh pr list --repo "$REPO" --state open --limit 200 --search "author:dependabot[bot]" --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
           count=$(jq 'length' dependabot-prs.json)
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "Found $count Dependabot PR(s)."

--- a/.github/workflows/org-repo-health-check.yml
+++ b/.github/workflows/org-repo-health-check.yml
@@ -1,1 +1,125 @@
-404: Not Found
+name: PR and Bug Triage
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # Every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: repo-pr-bug-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure expected labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ensure_label() {
+            local name="$1"
+            local color="$2"
+            local desc="$3"
+            gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" 2>/dev/null || \
+              gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc" >/dev/null
+          }
+
+          ensure_label "needs-review" "0366D6" "Queued for reviewer assignment"
+          ensure_label "has-conflicts" "B60205" "PR has merge conflicts"
+          ensure_label "draft" "6E7781" "Draft pull request"
+          ensure_label "size:xl" "5319E7" "Large PR"
+          ensure_label "priority:high" "D93F0B" "High priority"
+          ensure_label "priority:medium" "FBCA04" "Medium priority"
+          ensure_label "priority:normal" "0E8A16" "Normal priority"
+          ensure_label "severity:critical" "B60205" "Critical issue"
+          ensure_label "severity:high" "D93F0B" "High severity issue"
+          ensure_label "severity:normal" "0E8A16" "Normal severity issue"
+          ensure_label "security" "B60205" "Security-related issue"
+
+      - name: Triage open pull requests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          prs=$(gh pr list --repo "$REPO" --state open --limit 200 --json number,title,mergeStateStatus,isDraft,additions,deletions)
+          count=$(echo "$prs" | jq 'length')
+          echo "Found $count open PR(s)."
+          echo "$prs" > pr-triage-report.json
+
+          if [ "$count" -eq 0 ]; then
+            exit 0
+          fi
+
+          echo "$prs" | jq -c '.[]' | while read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            title=$(echo "$pr" | jq -r '.title')
+            merge_state=$(echo "$pr" | jq -r '.mergeStateStatus')
+            is_draft=$(echo "$pr" | jq -r '.isDraft')
+            additions=$(echo "$pr" | jq -r '.additions // 0')
+            deletions=$(echo "$pr" | jq -r '.deletions // 0')
+            changed=$((additions + deletions))
+
+            echo "Processing PR #$number ($title)"
+            gh pr edit "$number" --repo "$REPO" --add-label "needs-review" || true
+
+            if [ "$merge_state" = "DIRTY" ]; then
+              gh pr edit "$number" --repo "$REPO" --add-label "priority:high" --add-label "has-conflicts" || true
+              gh pr comment "$number" --repo "$REPO" --body "Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks." || true
+            elif [ "$changed" -gt 800 ]; then
+              gh pr edit "$number" --repo "$REPO" --add-label "priority:medium" --add-label "size:xl" || true
+            else
+              gh pr edit "$number" --repo "$REPO" --add-label "priority:normal" || true
+            fi
+
+            if [ "$is_draft" = "true" ]; then
+              gh pr edit "$number" --repo "$REPO" --add-label "draft" || true
+            fi
+          done
+
+      - name: Triage open issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          issues=$(gh issue list --repo "$REPO" --state open --limit 200 --json number,title)
+          count=$(echo "$issues" | jq 'length')
+          echo "Found $count open issue(s)."
+          echo "$issues" > issue-triage-report.json
+
+          if [ "$count" -eq 0 ]; then
+            exit 0
+          fi
+
+          echo "$issues" | jq -c '.[]' | while read -r issue; do
+            number=$(echo "$issue" | jq -r '.number')
+            title=$(echo "$issue" | jq -r '.title' | tr '[:upper:]' '[:lower:]')
+
+            if echo "$title" | grep -Eq 'security|vulnerability|xss|sql injection|rce'; then
+              gh issue edit "$number" --repo "$REPO" --add-label "severity:critical" --add-label "security" || true
+            elif echo "$title" | grep -Eq 'crash|data loss|broken|cannot|fails|error'; then
+              gh issue edit "$number" --repo "$REPO" --add-label "severity:high" || true
+            else
+              gh issue edit "$number" --repo "$REPO" --add-label "severity:normal" || true
+            fi
+          done
+
+      - name: Upload triage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: triage-reports
+          path: |
+            pr-triage-report.json
+            issue-triage-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/org-repo-health-check.yml
+++ b/.github/workflows/org-repo-health-check.yml
@@ -75,10 +75,13 @@ jobs:
 
             if [ "$merge_state" = "DIRTY" ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:high" --add-label "has-conflicts" || true
-              if ! gh pr view "$number" --repo "$REPO" --json comments --jq '.comments[].body' | grep -Fxq "$conflict_comment"; then
-                gh pr comment "$number" --repo "$REPO" --body "$conflict_comment" || true
+
+              conflict_note="Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks."
+              existing_conflict_note_count=$(gh pr view "$number" --repo "$REPO" --json comments 2>/dev/null | jq --arg msg "$conflict_note" '[.comments[] | select(.body == $msg)] | length' || echo "0")
+              if [ "${existing_conflict_note_count:-0}" -eq 0 ]; then
+                gh pr comment "$number" --repo "$REPO" --body "$conflict_note" || true
               else
-                echo "Conflict comment already exists for PR #$number; skipping duplicate comment."
+                echo "Conflict triage comment already exists for PR #$number; skipping duplicate comment."
               fi
             elif [ "$changed" -gt 800 ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:medium" --add-label "size:xl" || true

--- a/.github/workflows/org-repo-health-check.yml
+++ b/.github/workflows/org-repo-health-check.yml
@@ -68,13 +68,18 @@ jobs:
             additions=$(echo "$pr" | jq -r '.additions // 0')
             deletions=$(echo "$pr" | jq -r '.deletions // 0')
             changed=$((additions + deletions))
+            conflict_comment="Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks."
 
             echo "Processing PR #$number ($title)"
             gh pr edit "$number" --repo "$REPO" --add-label "needs-review" || true
 
             if [ "$merge_state" = "DIRTY" ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:high" --add-label "has-conflicts" || true
-              gh pr comment "$number" --repo "$REPO" --body "Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks." || true
+              if ! gh pr view "$number" --repo "$REPO" --json comments --jq '.comments[].body' | grep -Fxq "$conflict_comment"; then
+                gh pr comment "$number" --repo "$REPO" --body "$conflict_comment" || true
+              else
+                echo "Conflict comment already exists for PR #$number; skipping duplicate comment."
+              fi
             elif [ "$changed" -gt 800 ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:medium" --add-label "size:xl" || true
             else


### PR DESCRIPTION
### Motivation

- Improve automation for merging pull requests by enabling auto-merge when checks succeed or when PRs are eligible. 
- Add a Dependabot batch manager to auto-fix lint/build issues on Dependabot branches and attempt automated merges. 
- Provide an automated PR and issue triage job to ensure consistent labels and surface high-priority or conflicted items.

### Description

- Update `/.github/workflows/auto-merge.yml` to add `concurrency`, broaden the run condition to handle both `pull_request` events and successful `check_suite` conclusions, skip draft PRs, and centralize auto-merge logic using `gh pr merge` and a scan over open PRs with `gh pr list` and `jq` to merge `CLEAN` non-draft PRs.
- Add `/.github/workflows/org-dependabot-batch-manager.yml` which runs on a 6-hour schedule and on demand, checks out the repo, sets up Node.js, finds open Dependabot PRs with `gh pr list`, runs `npm run lint -- --fix` and `npm run build`, commits/pushes fixes, attempts `gh pr merge` for non-draft PRs, and uploads a `dependabot-prs.json` artifact.
- Add `/.github/workflows/org-repo-health-check.yml` which runs on a 6-hour schedule and on demand, ensures a set of expected labels exist, triages open PRs by adding `needs-review`, flagging conflicts (`has-conflicts`) and priority/size labels based on `mergeStateStatus` and change size, triages issues by labeling severity from title keywords, and uploads triage report artifacts.

### Testing

- No automated tests were executed for these workflow definition changes; validation will occur when GitHub Actions runs the workflows on their next scheduled or triggered executions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c38202d39883288fae8201632cb5ad)