### PR TITLE
Inventory & persistence: add collection store, UI, import/export, and fix ESLint dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
-        "eslint": "^10.1.0",
+        "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
@@ -945,44 +945,143 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -999,27 +1098,27 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1790,13 +1889,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2155,6 +2247,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2256,6 +2371,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2264,6 +2396,33 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2432,30 +2591,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-      "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.3",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -2465,7 +2627,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2473,7 +2636,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -2511,19 +2674,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2542,19 +2703,76 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2762,6 +2980,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2882,6 +3110,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -2979,6 +3220,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3483,11 +3731,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
-    "eslint": "^10.1.0",
+    "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",

--- a/src/pages/Collection.tsx
+++ b/src/pages/Collection.tsx
@@ -1,15 +1,168 @@
-// Collection page: Placeholder for category/item management
-import { Typography, Paper } from '@mui/material';
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+  MenuItem,
+  IconButton,
+} from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import {
+  addCollectionItem,
+  getCollectionItems,
+  getCollectionSummary,
+  removeCollectionItem,
+  type CollectionCategory,
+} from '../store/collectionStore';
+
+const categories: CollectionCategory[] = ['Cards', 'Coins', 'Comics', 'Figures', 'Games', 'Other'];
 
 export default function Collection() {
+  const [items, setItems] = useState(getCollectionItems);
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState<CollectionCategory>('Cards');
+  const [quantity, setQuantity] = useState(1);
+  const [estimatedValue, setEstimatedValue] = useState(0);
+  const [notes, setNotes] = useState('');
+
+  const summary = useMemo(() => getCollectionSummary(items), [items]);
+
+  const refreshItems = () => setItems(getCollectionItems());
+
+  const handleAddItem = () => {
+    if (!name.trim()) return;
+
+    addCollectionItem({
+      name: name.trim(),
+      category,
+      quantity: Math.max(1, quantity),
+      estimatedValue: Math.max(0, estimatedValue),
+      notes: notes.trim() || undefined,
+    });
+
+    setName('');
+    setCategory('Cards');
+    setQuantity(1);
+    setEstimatedValue(0);
+    setNotes('');
+    refreshItems();
+  };
+
+  const handleRemove = (id: string) => {
+    removeCollectionItem(id);
+    refreshItems();
+  };
+
   return (
-    <Paper elevation={2} sx={{ p: 4 }}>
-      <Typography variant="h5" gutterBottom>
-        Your Collection
-      </Typography>
-      <Typography color="text.secondary">
-        Manage your categories and items here. (Coming soon)
-      </Typography>
-    </Paper>
+    <Stack spacing={3}>
+      <Paper elevation={2} sx={{ p: 3 }}>
+        <Typography variant="h5" gutterBottom>
+          Your Collection
+        </Typography>
+        <Typography color="text.secondary" sx={{ mb: 2 }}>
+          Add items to create a lightweight inventory with estimated value tracking.
+        </Typography>
+
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} flexWrap="wrap" sx={{ mb: 2 }}>
+          <Chip label={`Types: ${summary.itemTypes}`} color="primary" variant="outlined" />
+          <Chip label={`Units: ${summary.totalUnits}`} color="secondary" variant="outlined" />
+          <Chip label={`Estimated value: $${summary.totalEstimatedValue.toFixed(2)}`} variant="outlined" />
+        </Stack>
+
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateColumns: { xs: '1fr', md: '2fr 1fr 1fr 1fr' },
+          }}
+        >
+          <TextField label="Item name" value={name} onChange={(event) => setName(event.target.value)} required />
+          <TextField
+            label="Category"
+            value={category}
+            onChange={(event) => setCategory(event.target.value as CollectionCategory)}
+            select
+          >
+            {categories.map((itemCategory) => (
+              <MenuItem key={itemCategory} value={itemCategory}>
+                {itemCategory}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Quantity"
+            type="number"
+            value={quantity}
+            onChange={(event) => setQuantity(Number(event.target.value) || 0)}
+            inputProps={{ min: 1 }}
+          />
+          <TextField
+            label="Estimated value ($)"
+            type="number"
+            value={estimatedValue}
+            onChange={(event) => setEstimatedValue(Number(event.target.value) || 0)}
+            inputProps={{ min: 0, step: '0.01' }}
+          />
+          <TextField
+            label="Notes (optional)"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            sx={{ gridColumn: { xs: '1', md: '1 / span 3' } }}
+          />
+          <Button variant="contained" onClick={handleAddItem} sx={{ minHeight: 56 }}>
+            Add item
+          </Button>
+        </Box>
+      </Paper>
+
+      <Paper elevation={2} sx={{ p: 3 }}>
+        <Typography variant="h6" gutterBottom>
+          Inventory
+        </Typography>
+
+        {items.length === 0 ? (
+          <Alert severity="info">No items yet. Add your first collectible above.</Alert>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Item</TableCell>
+                <TableCell>Category</TableCell>
+                <TableCell align="right">Qty</TableCell>
+                <TableCell align="right">Est. Value</TableCell>
+                <TableCell>Notes</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {items.map((item) => (
+                <TableRow key={item.id} hover>
+                  <TableCell>{item.name}</TableCell>
+                  <TableCell>{item.category}</TableCell>
+                  <TableCell align="right">{item.quantity}</TableCell>
+                  <TableCell align="right">${(item.quantity * item.estimatedValue).toFixed(2)}</TableCell>
+                  <TableCell>{item.notes || '—'}</TableCell>
+                  <TableCell align="right">
+                    <IconButton aria-label={`Delete ${item.name}`} onClick={() => handleRemove(item.id)}>
+                      <DeleteOutlineIcon />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </Paper>
+    </Stack>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,17 +1,61 @@
-// Dashboard page: Welcome and summary
-import { Typography, Paper, Box } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { Alert, Box, Chip, Paper, Stack, Typography } from '@mui/material';
+import { COLLECTION_UPDATED_EVENT, getCollectionItems, getCollectionSummary } from '../store/collectionStore';
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+  }).format(value);
+}
 
 export default function Dashboard() {
+  const [items, setItems] = useState(getCollectionItems);
+
+  useEffect(() => {
+    const handleUpdate = () => setItems(getCollectionItems());
+    window.addEventListener(COLLECTION_UPDATED_EVENT, handleUpdate);
+    window.addEventListener('storage', handleUpdate);
+    return () => {
+      window.removeEventListener(COLLECTION_UPDATED_EVENT, handleUpdate);
+      window.removeEventListener('storage', handleUpdate);
+    };
+  }, []);
+
+  const summary = useMemo(() => getCollectionSummary(items), [items]);
+  const launchReadiness = [
+    { label: 'Inventory exists', done: summary.itemTypes > 0 },
+    { label: 'Estimated value calculated', done: summary.totalEstimatedValue > 0 },
+    { label: 'Import/export available', done: true },
+    { label: 'Marketplace prep available', done: true },
+  ];
+
   return (
     <Paper elevation={2} sx={{ p: 4 }}>
       <Typography variant="h4" gutterBottom>
         Welcome to Collectease
       </Typography>
       <Typography variant="body1" color="text.secondary">
-        Organize, value, and share your collectibles. Use the navigation to get started!
+        Organize, value, and share your collectibles.
       </Typography>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} mt={3} mb={2}>
+        <Chip label={`Item types: ${summary.itemTypes}`} color="primary" />
+        <Chip label={`Total units: ${summary.totalUnits}`} color="secondary" />
+        <Chip label={`Portfolio value: ${formatCurrency(summary.totalEstimatedValue)}`} />
+      </Stack>
+
       <Box mt={3}>
-        {/* Future: Add summary widgets here */}
+        <Typography variant="h6" gutterBottom>
+          Launch readiness
+        </Typography>
+        <Stack spacing={1}>
+          {launchReadiness.map((step) => (
+            <Alert key={step.label} severity={step.done ? 'success' : 'warning'}>
+              {step.label}
+            </Alert>
+          ))}
+        </Stack>
       </Box>
     </Paper>
   );

--- a/src/pages/ImportExport.tsx
+++ b/src/pages/ImportExport.tsx
@@ -1,25 +1,37 @@
-// Import/Export page: Placeholder
-import { Typography, Paper, Button, Box, FormControlLabel, Checkbox, Snackbar, Alert, CircularProgress } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  Paper,
+  Snackbar,
+  Stack,
+  Typography,
+} from '@mui/material';
 import { useRef, useState } from 'react';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
+import DownloadIcon from '@mui/icons-material/Download';
+import BackupTableIcon from '@mui/icons-material/BackupTable';
+import { getCollectionItems, replaceCollectionItems, type CollectionItem } from '../store/collectionStore';
 
-// Simulated image search database (in-memory for now)
 const imageSearchDBKey = 'collectease-image-search-db';
 
 function saveImagesToSearchDB(images: string[]): string[] {
-  // Save images to localStorage for persistence
-  const existing = JSON.parse(localStorage.getItem(imageSearchDBKey) || '[]');
+  const existing = JSON.parse(localStorage.getItem(imageSearchDBKey) || '[]') as string[];
   const updated = [...existing, ...images];
   localStorage.setItem(imageSearchDBKey, JSON.stringify(updated));
   return updated;
 }
 
 function getImagesFromSearchDB(): string[] {
-  return JSON.parse(localStorage.getItem(imageSearchDBKey) || '[]');
+  return JSON.parse(localStorage.getItem(imageSearchDBKey) || '[]') as string[];
 }
 
 export default function ImportExport() {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const collectionImportRef = useRef<HTMLInputElement>(null);
   const [images, setImages] = useState<string[]>([]);
   const [searchable, setSearchable] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
@@ -37,30 +49,25 @@ export default function ImportExport() {
     setIsImporting(true);
     const newImages: string[] = [];
 
-    const filePromises = Array.from(files).map((file) => {
-      return new Promise<void>((resolve) => {
-        const reader = new FileReader();
-        if (file.type.startsWith('image/')) {
-          reader.onload = (e) => {
-            const imageUrl = e.target?.result as string;
-            newImages.push(imageUrl);
-            resolve();
-          };
-          reader.onerror = () => {
-            console.error('Failed to read file:', file.name);
-            resolve();
-          };
-          reader.readAsDataURL(file);
-        } else {
-          reader.onload = (e) => {
-            console.log('Imported file contents:', e.target?.result);
-            resolve();
-          };
-          reader.onerror = () => resolve();
-          reader.readAsText(file);
-        }
-      });
-    });
+    const filePromises = Array.from(files).map(
+      (file) =>
+        new Promise<void>((resolve) => {
+          const reader = new FileReader();
+          if (file.type.startsWith('image/')) {
+            reader.onload = (readerEvent) => {
+              const imageUrl = readerEvent.target?.result as string;
+              newImages.push(imageUrl);
+              resolve();
+            };
+            reader.onerror = () => resolve();
+            reader.readAsDataURL(file);
+          } else {
+            reader.onload = () => resolve();
+            reader.onerror = () => resolve();
+            reader.readAsText(file);
+          }
+        }),
+    );
 
     await Promise.all(filePromises);
     setImages((prev) => [...prev, ...newImages]);
@@ -73,41 +80,71 @@ export default function ImportExport() {
       setDbImages(getImagesFromSearchDB());
     }
 
-    let message = '';
-    if (imageCount > 0 && otherCount > 0) {
-      message = `Imported ${imageCount} images and ${otherCount} files.`;
-    } else if (imageCount > 0) {
-      message = `Imported ${imageCount} image${imageCount > 1 ? 's' : ''} successfully!`;
-    } else if (otherCount > 0) {
-      message = `Imported ${otherCount} file${otherCount > 1 ? 's' : ''} successfully!`;
-    }
+    const message =
+      imageCount > 0 && otherCount > 0
+        ? `Imported ${imageCount} images and ${otherCount} files.`
+        : imageCount > 0
+          ? `Imported ${imageCount} image${imageCount > 1 ? 's' : ''} successfully!`
+          : `Imported ${otherCount} file${otherCount > 1 ? 's' : ''} successfully!`;
 
-    if (message) {
-      setSnackbar({ open: true, message, severity: 'success' });
-    }
-
+    setSnackbar({ open: true, message, severity: 'success' });
     setIsImporting(false);
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleExport = () => {
-    try {
-      if (dbImages.length === 0) return;
-      const dataStr = JSON.stringify(dbImages, null, 2);
-      const blob = new Blob([dataStr], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `search-db-images-${new Date().toISOString().split('T')[0]}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-      setSnackbar({ open: true, message: 'Database exported successfully!', severity: 'success' });
-    } catch (error) {
-      console.error('Failed to export:', error);
-      setSnackbar({ open: true, message: 'Failed to export data. Please try again.', severity: 'error' });
+  const handleCollectionExport = () => {
+    const items = getCollectionItems();
+    if (items.length === 0) {
+      setSnackbar({ open: true, message: 'No collection items to export yet.', severity: 'error' });
+      return;
     }
+
+    const blob = new Blob([JSON.stringify(items, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `collectease-collection-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    setSnackbar({ open: true, message: 'Collection exported successfully.', severity: 'success' });
+  };
+
+  const handleCollectionImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as CollectionItem[];
+      if (!Array.isArray(parsed)) {
+        throw new Error('Invalid payload');
+      }
+      replaceCollectionItems(parsed);
+      setSnackbar({ open: true, message: 'Collection imported successfully.', severity: 'success' });
+    } catch {
+      setSnackbar({ open: true, message: 'Invalid JSON file. Import failed.', severity: 'error' });
+    }
+
+    if (collectionImportRef.current) {
+      collectionImportRef.current.value = '';
+    }
+  };
+
+  const handleSearchDBExport = () => {
+    if (dbImages.length === 0) return;
+    const dataStr = JSON.stringify(dbImages, null, 2);
+    const blob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `search-db-images-${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    setSnackbar({ open: true, message: 'Image database exported successfully.', severity: 'success' });
   };
 
   return (
@@ -116,16 +153,27 @@ export default function ImportExport() {
         Import & Export
       </Typography>
       <Typography color="text.secondary" gutterBottom>
-        Import your collection or export it to other platforms.
+        Move collection data between devices and stage media for searchable imports.
       </Typography>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} sx={{ my: 2 }}>
+        <Button variant="outlined" startIcon={<DownloadIcon />} onClick={handleCollectionExport}>
+          Export Collection JSON
+        </Button>
+        <Button variant="outlined" startIcon={<BackupTableIcon />} onClick={() => collectionImportRef.current?.click()}>
+          Import Collection JSON
+        </Button>
+      </Stack>
+      <input
+        type="file"
+        accept=".json"
+        ref={collectionImportRef}
+        style={{ display: 'none' }}
+        onChange={handleCollectionImport}
+      />
+
       <FormControlLabel
-        control={
-          <Checkbox
-            checked={searchable}
-            onChange={(_, checked) => setSearchable(checked)}
-            color="primary"
-          />
-        }
+        control={<Checkbox checked={searchable} onChange={(_, checked) => setSearchable(checked)} color="primary" />}
         label="Mark imported images as searchable (for image recognition/search)"
         sx={{ mb: 2 }}
       />
@@ -134,7 +182,6 @@ export default function ImportExport() {
         startIcon={isImporting ? <CircularProgress size={20} color="inherit" /> : <UploadFileIcon />}
         onClick={() => fileInputRef.current?.click()}
         disabled={isImporting}
-        sx={{ mt: 2 }}
       >
         {isImporting ? 'Importing...' : 'Import Files or Images'}
       </Button>
@@ -146,22 +193,16 @@ export default function ImportExport() {
         onChange={handleFileChange}
         multiple
       />
+
       {images.length > 0 && (
         <>
           <Typography variant="subtitle1" sx={{ mt: 3 }}>
             Imported Images:
           </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 2,
-              mt: 1,
-            }}
-          >
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 1 }}>
             {images.map((img, idx) => (
               <Box
-                key={idx}
+                key={`imported-${idx}`}
                 sx={{
                   width: 120,
                   height: 120,
@@ -174,33 +215,22 @@ export default function ImportExport() {
                   background: '#fafafa',
                 }}
               >
-                <img
-                  src={img}
-                  alt={`imported-${idx}`}
-                  loading="lazy"
-                  style={{ maxWidth: '100%', maxHeight: '100%' }}
-                />
+                <img src={img} alt={`imported-${idx}`} loading="lazy" style={{ maxWidth: '100%', maxHeight: '100%' }} />
               </Box>
             ))}
           </Box>
         </>
       )}
+
       {dbImages.length > 0 && (
         <>
           <Typography variant="subtitle1" sx={{ mt: 4 }}>
             Images in Search Database:
           </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 2,
-              mt: 1,
-            }}
-          >
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 1 }}>
             {dbImages.map((img, idx) => (
               <Box
-                key={idx}
+                key={`dbimg-${idx}`}
                 sx={{
                   width: 80,
                   height: 80,
@@ -213,31 +243,22 @@ export default function ImportExport() {
                   background: '#e3f2fd',
                 }}
               >
-                <img
-                  src={img}
-                  alt={`dbimg-${idx}`}
-                  loading="lazy"
-                  style={{ maxWidth: '100%', maxHeight: '100%' }}
-                />
+                <img src={img} alt={`dbimg-${idx}`} loading="lazy" style={{ maxWidth: '100%', maxHeight: '100%' }} />
               </Box>
             ))}
           </Box>
         </>
       )}
-      <Button
-        variant="outlined"
-        sx={{ mt: 4 }}
-        onClick={handleExport}
-        disabled={dbImages.length === 0}
-      >
+
+      <Button variant="outlined" sx={{ mt: 4 }} onClick={handleSearchDBExport} disabled={dbImages.length === 0}>
         Export Search Database
       </Button>
 
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={6000}
-        onClose={() => setSnackbar({ ...snackbar, open: false })}
-      >
+      <Alert severity="info" sx={{ mt: 3 }}>
+        Tip: collection exports are launch-ready backups you can keep in versioned cloud storage.
+      </Alert>
+
+      <Snackbar open={snackbar.open} autoHideDuration={6000} onClose={() => setSnackbar({ ...snackbar, open: false })}>
         <Alert
           onClose={() => setSnackbar({ ...snackbar, open: false })}
           severity={snackbar.severity}

--- a/src/store/collectionStore.ts
+++ b/src/store/collectionStore.ts
@@ -1,0 +1,82 @@
+export type CollectionCategory =
+  | 'Cards'
+  | 'Coins'
+  | 'Comics'
+  | 'Figures'
+  | 'Games'
+  | 'Other';
+
+export interface CollectionItem {
+  id: string;
+  name: string;
+  category: CollectionCategory;
+  quantity: number;
+  estimatedValue: number;
+  notes?: string;
+  createdAt: string;
+}
+
+const COLLECTION_KEY = 'collectease-collection-items';
+export const COLLECTION_UPDATED_EVENT = 'collectease:collection-updated';
+
+function hasWindow(): boolean {
+  return typeof window !== 'undefined';
+}
+
+export function getCollectionItems(): CollectionItem[] {
+  if (!hasWindow()) return [];
+
+  const raw = window.localStorage.getItem(COLLECTION_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as CollectionItem[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function saveCollectionItems(items: CollectionItem[]): void {
+  if (!hasWindow()) return;
+  window.localStorage.setItem(COLLECTION_KEY, JSON.stringify(items));
+  window.dispatchEvent(new Event(COLLECTION_UPDATED_EVENT));
+}
+
+export function addCollectionItem(item: Omit<CollectionItem, 'id' | 'createdAt'>): CollectionItem {
+  const next: CollectionItem = {
+    ...item,
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+  };
+
+  const items = getCollectionItems();
+  saveCollectionItems([next, ...items]);
+  return next;
+}
+
+export function removeCollectionItem(id: string): void {
+  const filtered = getCollectionItems().filter((item) => item.id !== id);
+  saveCollectionItems(filtered);
+}
+
+export function replaceCollectionItems(items: CollectionItem[]): void {
+  saveCollectionItems(items);
+}
+
+export function getCollectionSummary(items = getCollectionItems()): {
+  itemTypes: number;
+  totalUnits: number;
+  totalEstimatedValue: number;
+} {
+  return items.reduce(
+    (acc, item) => {
+      acc.itemTypes += 1;
+      acc.totalUnits += item.quantity;
+      acc.totalEstimatedValue += item.estimatedValue * item.quantity;
+      return acc;
+    },
+    { itemTypes: 0, totalUnits: 0, totalEstimatedValue: 0 },
+  );
+}


### PR DESCRIPTION
### Motivation
- Make the app launch-ready by replacing placeholders with real inventory workflows and persistent storage. 
- Provide reliable typed local persistence and cross-page update events so dashboards and exports reflect real data.
- Improve data portability (collection backup/restore) and media import/export for final QA and market launch.
- Fix dependency resolution so linting and CI-style checks run deterministically in build environments.

### Description
- Added a typed `collectionStore` (`src/store/collectionStore.ts`) that persists collection items to `localStorage`, exposes `addCollectionItem`, `removeCollectionItem`, `replaceCollectionItems`, `getCollectionItems`, `getCollectionSummary`, and dispatches `COLLECTEASE_UPDATED_EVENT` for cross-tab/page updates. 
- Replaced the placeholder Collection page with a working inventory manager (`src/pages/Collection.tsx`) that supports adding/deleting items with category, quantity, estimated value, notes, and shows live totals.
- Upgraded the Dashboard (`src/pages/Dashboard.tsx`) to consume the store, show live KPIs (types, units, portfolio value) and a launch-readiness checklist that updates from collection data.
- Expanded Import/Export (`src/pages/ImportExport.tsx`) to support collection JSON export/import (backup/restore), improved media import flows, searchable image DB export, and user feedback via Snackbar/Alert.
- Fixed lint/install breakage by aligning ESLint to a plugin-compatible version in `package.json` and regenerated the lockfile (`package-lock.json`) so dev dependency resolution succeeds.

### Testing
- Initial `npm ci` failed due to an ESLint peer dependency conflict, which was resolved by adjusting the ESLint version in `package.json` (failure expected and addressed).
- `npm install` completed successfully and installed dependencies.
- `npm run lint` executed successfully with no blocking errors.
- `npm run build` completed successfully and produced a production build (`vite build`) with output assets under `dist/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894dbdd848328946bcc31015f7224)