### PR TITLE
Follow-up: paginate PR queries and avoid duplicate conflict comments

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
             exit 0
           fi
 
-          gh pr list --repo "$REPO" --state open --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
+          gh pr list --repo "$REPO" --state open --limit 200 --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             draft=$(echo "$pr" | jq -r '.isDraft')
             merge_state=$(echo "$pr" | jq -r '.mergeStateStatus')

--- a/.github/workflows/org-dependabot-batch-manager.yml
+++ b/.github/workflows/org-dependabot-batch-manager.yml
@@ -39,7 +39,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh pr list --repo "$REPO" --state open --search "author:dependabot[bot]" --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
+          gh pr list --repo "$REPO" --state open --search "author:dependabot[bot]" --limit 200 --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
           count=$(jq 'length' dependabot-prs.json)
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "Found $count Dependabot PR(s)."

--- a/.github/workflows/org-repo-health-check.yml
+++ b/.github/workflows/org-repo-health-check.yml
@@ -74,7 +74,16 @@ jobs:
 
             if [ "$merge_state" = "DIRTY" ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:high" --add-label "has-conflicts" || true
-              gh pr comment "$number" --repo "$REPO" --body "Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks." || true
+              existing_conflict_comment=$(
+                gh pr view "$number" --repo "$REPO" --json comments --jq '.comments[] | select(.author.login == "github-actions[bot]") | .body' \
+                  | grep -Fxc "Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks." || true
+              )
+
+              if [ "${existing_conflict_comment:-0}" -eq 0 ]; then
+                gh pr comment "$number" --repo "$REPO" --body "Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks." || true
+              else
+                echo "Conflict notice already present for PR #$number; skipping duplicate comment."
+              fi
             elif [ "$changed" -gt 800 ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:medium" --add-label "size:xl" || true
             else


### PR DESCRIPTION
### Motivation

- Ensure batch automation and auto-merge scanning do not silently skip PRs because `gh pr list` defaults to 30 items per page. 
- Reduce repeated triage noise by preventing the scheduled triage job from posting the same conflict comment on every run.

### Description

- Add `--limit 200` to the Dependabot discovery query in `.github/workflows/org-dependabot-batch-manager.yml` so more than the default 30 Dependabot PRs are processed. 
- Add `--limit 200` to the open-PR scan used by the `check_suite` path in `.github/workflows/auto-merge.yml` so clean, non-draft PRs beyond the first page are considered for auto-merge. 
- Update `.github/workflows/org-repo-health-check.yml` to check existing `github-actions[bot]` comments and only post the standardized conflict notice if it is not already present, avoiding duplicate comments.

### Testing

- Ran `git diff --check` which reported no whitespace or diff issues. 
- Verified workflow diffs and basic shell syntax consistency for the updated run blocks. 
- `yamllint` was not available in this environment so formal YAML linting could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e899c985ac83288a1b7ac9e7881470)