### PR TITLE
Follow-up: fix workflow pagination and suppress duplicate conflict comments

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -36,7 +36,7 @@ jobs:
             exit 0
           fi
 
-          gh pr list --repo "$REPO" --state open --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
+          gh pr list --repo "$REPO" --state open --limit 200 --json number,isDraft,mergeStateStatus | jq -c '.[]' | while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             draft=$(echo "$pr" | jq -r '.isDraft')
             merge_state=$(echo "$pr" | jq -r '.mergeStateStatus')

--- a/.github/workflows/org-dependabot-batch-manager.yml
+++ b/.github/workflows/org-dependabot-batch-manager.yml
@@ -39,7 +39,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh pr list --repo "$REPO" --state open --search "author:dependabot[bot]" --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
+          gh pr list --repo "$REPO" --state open --limit 200 --search "author:dependabot[bot]" --json number,headRefName,mergeStateStatus,isDraft > dependabot-prs.json
           count=$(jq 'length' dependabot-prs.json)
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "Found $count Dependabot PR(s)."

--- a/.github/workflows/org-repo-health-check.yml
+++ b/.github/workflows/org-repo-health-check.yml
@@ -60,6 +60,8 @@ jobs:
             exit 0
           fi
 
+          conflict_message="Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks."
+
           echo "$prs" | jq -c '.[]' | while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             title=$(echo "$pr" | jq -r '.title')
@@ -74,7 +76,12 @@ jobs:
 
             if [ "$merge_state" = "DIRTY" ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:high" --add-label "has-conflicts" || true
-              gh pr comment "$number" --repo "$REPO" --body "Automated triage: this PR currently has merge conflicts. Please update with the latest base branch and re-run checks." || true
+              existing_conflict_comment_count=$(gh pr view "$number" --repo "$REPO" --json comments --jq --arg msg "$conflict_message" '[.comments[] | select(.author.login == "github-actions[bot]" and (.body | contains($msg)))] | length' || echo "0")
+              if [ "$existing_conflict_comment_count" = "0" ]; then
+                gh pr comment "$number" --repo "$REPO" --body "$conflict_message" || true
+              else
+                echo "Conflict comment already exists for PR #$number; skipping duplicate comment."
+              fi
             elif [ "$changed" -gt 800 ]; then
               gh pr edit "$number" --repo "$REPO" --add-label "priority:medium" --add-label "size:xl" || true
             else


### PR DESCRIPTION
### Motivation

- Address reviewer feedback that `gh pr list` default pagination (30 results) caused open PRs and Dependabot PRs to be skipped by automation. 
- Reduce notification noise from scheduled triage by preventing the same merge-conflict comment from being posted repeatedly.

### Description

- Add `--limit 200` to the `gh pr list` call used in the `check_suite` path of `/.github/workflows/auto-merge.yml` so open PR discovery evaluates more than the default 30 PRs. 
- Add `--limit 200` to the Dependabot discovery in `/.github/workflows/org-dependabot-batch-manager.yml` so batch processing includes more Dependabot PRs. 
- Update `/.github/workflows/org-repo-health-check.yml` to introduce a `conflict_message` variable and check existing `github-actions[bot]` comments via `gh pr view --json comments --jq` before posting the merge-conflict reminder to suppress duplicate comments.

### Testing

- Ran `rg -n "^(<<<<<<<|=======|>>>>>>>)" .github/workflows` to confirm no merge conflict markers remain in the modified workflow files and found none. 
- Reviewed diffs with `git diff -- .github/workflows` to verify only the intended workflow edits were applied. 
- No CI workflows were executed in this environment; runtime validation will occur when GitHub Actions runs the updated workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e899f0ceb08328baf85af030ad0751)